### PR TITLE
fix: error body not set on AuthErrors

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 class AuthError extends Error {
   constructor (err) {
-    super(err.error_description)
+    super(err.message || err.error_description)
     this.name = 'AuthError'
     Object.assign(this, err)
   }
@@ -8,7 +8,7 @@ class AuthError extends Error {
 
 class FetchError extends Error {
   constructor (resp, body) {
-    super(resp.statusText)
+    super(resp.message || resp.statusText)
     this.name = 'FetchError'
     this.resp = resp
     this.status = resp.status

--- a/src/request.js
+++ b/src/request.js
@@ -80,7 +80,7 @@ async function request (apiRoot, token, route, method, query = {}, options = {},
     }).then(throwWhenStatusNotOk)
   } catch (err) {
     if (err.resp?.headers.get('WWW-Authenticate')) {
-      const authError = splitToObject(err.resp.headers.get('WWW-Authenticate').replace(/^Bearer /, ''))
+      const authError = Object.assign(err, splitToObject(err.resp.headers.get('WWW-Authenticate').replace(/^Bearer /, '')))
       throw new AuthError(authError)
     } else {
       throw err

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,5 @@
 import Query from '@/Query'
-import { splitToObject } from '@/utils'
-import { throwWhenStatusNotOk, AuthError } from '@/errors'
+import { throwWhenStatusNotOk } from '@/errors'
 
 const acceptHeaderMap = {
   '': 'application/json',
@@ -70,22 +69,13 @@ async function request (apiRoot, token, route, method, query = {}, options = {},
 
   const url = new Query(apiRoot, route, query)
 
-  try {
-    // send all body types the fetch api recognizes as described here https://developer.mozilla.org/de/docs/Web/API/WindowOrWorkerGlobalScope/fetch as-is, stringify the rest
-    return await fetch(url.toString(), {
-      method,
-      headers,
-      body: isJSONBody ? JSON.stringify(body) : body,
-      signal: options.signal
-    }).then(throwWhenStatusNotOk)
-  } catch (err) {
-    if (err.resp?.headers.get('WWW-Authenticate')) {
-      const authError = Object.assign(err, splitToObject(err.resp.headers.get('WWW-Authenticate').replace(/^Bearer /, '')))
-      throw new AuthError(authError)
-    } else {
-      throw err
-    }
-  }
+  // send all body types the fetch api recognizes as described here https://developer.mozilla.org/de/docs/Web/API/WindowOrWorkerGlobalScope/fetch as-is, stringify the rest
+  return await fetch(url.toString(), {
+    method,
+    headers,
+    body: isJSONBody ? JSON.stringify(body) : body,
+    signal: options.signal
+  }).then(throwWhenStatusNotOk)
 }
 
 export default request

--- a/tests/fetch.mock.js
+++ b/tests/fetch.mock.js
@@ -148,7 +148,12 @@ export default async req => {
     case '/404':
     case '/api/404':
       return {
-        body: '{}',
+        body: JSON.stringify({
+          hint: '404 error hint',
+          details: '404 error details',
+          code: '404 error code',
+          message: '404 error message'
+        }),
         init: {
           status: 404,
           statusText: 'Not found',
@@ -160,9 +165,15 @@ export default async req => {
     default:
       if (req.headers.get('Authorization') === 'Bearer expired-token') {
         return {
-          body: '',
+          body: JSON.stringify({
+            hint: '401 error hint',
+            details: '401 error details',
+            code: '401 error code',
+            message: '401 error message'
+          }),
           init: {
             status: 401,
+            statusText: 'Not authorized',
             headers: {
               'WWW-Authenticate': 'Bearer error="invalid_token", error_description="JWT expired"'
             }

--- a/tests/unit/Errors.spec.js
+++ b/tests/unit/Errors.spec.js
@@ -1,41 +1,22 @@
 import { AuthError, FetchError } from '@/errors'
 
 describe('AuthError', () => {
-  it('uses message when set', () => {
+  it('parses error and error_description from WWW-Authenticate header', () => {
     try {
       throw new AuthError({
-        message: 'message',
-        error_description: 'description'
+        headers: new Headers({
+          'WWW-Authenticate': 'Bearer error="invalid_token", error_description="JWT expired"'
+        })
       })
     } catch (e) {
-      expect(e.message).toBe('message')
-    }
-  })
-
-  it('uses error_description when message not set', () => {
-    try {
-      throw new AuthError({
-        error_description: 'description'
-      })
-    } catch (e) {
-      expect(e.message).toBe('description')
+      expect(e.error).toBe('invalid_token')
+      expect(e.error_description).toBe('JWT expired')
     }
   })
 })
 
 describe('FetchError', () => {
-  it('uses message when set', () => {
-    try {
-      throw new FetchError({
-        message: 'message',
-        statusText: 'status text'
-      })
-    } catch (e) {
-      expect(e.message).toBe('message')
-    }
-  })
-
-  it('uses statusText when message not set', () => {
+  it('uses statusText as message', () => {
     try {
       throw new FetchError({
         statusText: 'status text'

--- a/tests/unit/Errors.spec.js
+++ b/tests/unit/Errors.spec.js
@@ -1,0 +1,47 @@
+import { AuthError, FetchError } from '@/errors'
+
+describe('AuthError', () => {
+  it('uses message when set', () => {
+    try {
+      throw new AuthError({
+        message: 'message',
+        error_description: 'description'
+      })
+    } catch (e) {
+      expect(e.message).toBe('message')
+    }
+  })
+
+  it('uses error_description when message not set', () => {
+    try {
+      throw new AuthError({
+        error_description: 'description'
+      })
+    } catch (e) {
+      expect(e.message).toBe('description')
+    }
+  })
+})
+
+describe('FetchError', () => {
+  it('uses message when set', () => {
+    try {
+      throw new FetchError({
+        message: 'message',
+        statusText: 'status text'
+      })
+    } catch (e) {
+      expect(e.message).toBe('message')
+    }
+  })
+
+  it('uses statusText when message not set', () => {
+    try {
+      throw new FetchError({
+        statusText: 'status text'
+      })
+    } catch (e) {
+      expect(e.message).toBe('status text')
+    }
+  })
+})

--- a/tests/unit/Request.spec.js
+++ b/tests/unit/Request.spec.js
@@ -1,5 +1,6 @@
 import request from '@/request'
 import GenericModel from '@/GenericModel'
+import { FetchError, AuthError } from '@/errors'
 
 describe('request method', () => {
   beforeEach(() => {
@@ -32,6 +33,33 @@ describe('request method', () => {
     expect(fetch).toHaveBeenLastCalledWith('http://localhost/api/clients', expect.objectContaining({
       method: 'DELETE'
     }))
+  })
+
+  it('correctly throws FetchError with full error body', async () => {
+    expect.assertions(5)
+    try {
+      await request('/api', '', '404', 'GET', {})
+    } catch (e) {
+      expect(e instanceof FetchError).toBe(true)
+      expect(e.code).toBe('404 error code')
+      expect(e.hint).toBe('404 error hint')
+      expect(e.details).toBe('404 error details')
+      expect(e.message).toBe('404 error message')
+    }
+  })
+
+  it('correctly throws AuthError with full error body', async () => {
+    expect.assertions(5)
+    try {
+      await request('/autherror', 'expired-token', '', 'GET', {})
+      console.log(fetch.mock.calls[0][1].headers)
+    } catch (e) {
+      expect(e instanceof AuthError).toBe(true)
+      expect(e.code).toBe('401 error code')
+      expect(e.hint).toBe('401 error hint')
+      expect(e.details).toBe('401 error details')
+      expect(e.message).toBe('401 error message')
+    }
   })
 
   it('does not throw if query argument is undefined', async () => {


### PR DESCRIPTION
This PR fixes an bug, where the error body was not set on AuthErrors. The error body contains information from PostgREST that should be available to the user.