### PR TITLE
feat: query syntax ignores empty conditional objects

### DIFF
--- a/src/Query.js
+++ b/src/Query.js
@@ -146,6 +146,7 @@ class Query extends URL {
         const strValue = this._parseConditions(value).map(({ key: k, value: v }) => {
           return isLogicalOperator(k) ? `${k}${v}` : `${k}.${v}`
         }).join(',')
+        if (!strValue) return undefined
         return {
           key,
           value: `(${strValue})`

--- a/tests/unit/Query.spec.js
+++ b/tests/unit/Query.spec.js
@@ -112,6 +112,11 @@ describe('Query', () => {
       }
     }, 'not.and=(grade.gte.91,student.is.false,not.or(age.gte.15,age.not.is.null))')
 
+    itt('ignores empty logical operator', {
+      and: {},
+      or: {}
+    }, '')
+
     itt('supports full-text search operator options in key', { 'my_tsv.fts(french)': 'amusant' }, 'my_tsv=fts(french).amusant')
 
     itt('supports "in" operator with array', { 'id.in': [1, 2, 3] }, 'id=in.(1,2,3)')


### PR DESCRIPTION
Resolves #65.