### PR TITLE
Expose setDefaultHeaders in the public library interface

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -109,6 +109,33 @@ The `vue-postgrest` module exports a plugin, a mixin and several helper function
   }
   ```
 
+### setDefaultHeaders(headers)
+
+- **Type:** `Function`
+
+- **Arguments:**
+  - `{object} headers`
+
+- **Returns:** `undefined`
+
+- **Usage:**
+
+  Set default headers sent with every request to the API. Useful for setting headers globally after the plugin has been installed, e.g. in response to a user action.
+
+  ::: tip
+  You can also set default headers at install time via the [plugin option](./#headers).
+  :::
+
+- **Example:**
+
+  ``` js
+  import { setDefaultHeaders } from 'vue-postgrest'
+
+  setDefaultHeaders({
+    'Accept-Language': 'en'
+  })
+  ```
+
 ### usePostgrest(apiRoot, token)
 
 - **Type:** `Function`

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import Plugin from '@/Plugin'
 import { resetSchemaCache, setDefaultToken } from '@/Schema'
+import { setDefaultHeaders } from '@/request'
 import pg from '@/mixin'
 import { AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError } from '@/errors'
 import usePostgrest from '@/use'
 
-export { pg, AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError, resetSchemaCache, setDefaultToken, usePostgrest, Plugin as default }
+export { pg, AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError, resetSchemaCache, setDefaultHeaders, setDefaultToken, usePostgrest, Plugin as default }


### PR DESCRIPTION
This lets users change the default headers sent in all requests of an already instanciated vue postgrest instance. 