### PR TITLE
Use internal fetch wrapper in fetchSchema

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -1,6 +1,6 @@
 import Postgrest from './Postgrest'
 import { setDefaultRoot } from './Schema'
-import { setDefaultHeaders } from './request'
+import { setDefaultHeaders } from './headers'
 import usePostgrest from './use'
 
 export default {

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -3,6 +3,7 @@ import RPC from '@/RPC'
 import request from '@/request'
 import { throwWhenStatusNotOk, SchemaNotFoundError } from '@/errors'
 import ObservableFunction from '@/ObservableFunction'
+import { getDefaultHeaders } from '@/headers'
 
 let schemaCache = {}
 
@@ -84,7 +85,7 @@ export default class Schema extends Function {
   }
 
   async _fetchSchema (apiRoot, token) {
-    const headers = new Headers()
+    const headers = new Headers(getDefaultHeaders())
     if (token) {
       headers.set('Authorization', `Bearer ${token}`)
     }

--- a/src/headers.js
+++ b/src/headers.js
@@ -1,0 +1,9 @@
+let defaultHeaders
+
+export function setDefaultHeaders (headers) {
+  defaultHeaders = new Headers(headers)
+}
+
+export function getDefaultHeaders () {
+  return defaultHeaders
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import Plugin from '@/Plugin'
 import { resetSchemaCache, setDefaultToken } from '@/Schema'
-import { setDefaultHeaders } from '@/request'
+import { setDefaultHeaders } from '@/headers'
 import pg from '@/mixin'
 import { AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError } from '@/errors'
 import usePostgrest from '@/use'

--- a/src/request.js
+++ b/src/request.js
@@ -1,11 +1,6 @@
 import Query from '@/Query'
 import { throwWhenStatusNotOk } from '@/errors'
-
-let defaultHeaders
-
-export function setDefaultHeaders (headers) {
-  defaultHeaders = new Headers(headers)
-}
+import { getDefaultHeaders } from '@/headers'
 
 const acceptHeaderMap = {
   '': 'application/json',
@@ -15,7 +10,7 @@ const acceptHeaderMap = {
 }
 
 async function request (apiRoot, token, route, method, query = {}, options = {}, body) {
-  const headers = new Headers(defaultHeaders)
+  const headers = new Headers(getDefaultHeaders())
 
   const isJSONBody = !([
     Blob,

--- a/tests/unit/Request.spec.js
+++ b/tests/unit/Request.spec.js
@@ -1,4 +1,5 @@
-import request, { setDefaultHeaders } from '@/request'
+import request from '@/request'
+import { setDefaultHeaders } from '@/headers'
 import GenericModel from '@/GenericModel'
 import { FetchError, AuthError } from '@/errors'
 

--- a/tests/unit/Schema.spec.js
+++ b/tests/unit/Schema.spec.js
@@ -2,6 +2,7 @@ import Schema, { resetSchemaCache } from '@/Schema'
 import Route from '@/Route'
 import RPC from '@/RPC'
 import { SchemaNotFoundError } from '@/index'
+import { setDefaultHeaders } from '@/headers'
 
 import request from '@/request'
 jest.mock('@/request')
@@ -31,6 +32,34 @@ describe('Schema', () => {
 
     it('does not throw for empty schema with correct header', async () => {
       await expect((new Schema('/empty')).$ready).resolves.toBeUndefined()
+    })
+  })
+
+  describe('default headers', () => {
+    afterEach(() => {
+      setDefaultHeaders(undefined)
+    })
+
+    it('sends default headers in fetchSchema request', async () => {
+      setDefaultHeaders({ 'Accept-Language': 'en' })
+      const schema = new Schema('/pk-api')
+      await schema.$ready
+      expect(fetch).toHaveBeenLastCalledWith('http://localhost/pk-api', expect.objectContaining({
+        headers: new Headers({ 'Accept-Language': 'en' })
+      }))
+    })
+
+    it('sends default headers alongside authorization header in fetchSchema request', async () => {
+      setDefaultHeaders({ 'Accept-Language': 'en' })
+      const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiamRvZSIsImV4cCI6MTQ3NTUxNjI1MH0.GYDZV3yM0gqvuEtJmfpplLBXSGYnke_Pvnl0tbKAjB'
+      const schema = new Schema('/pk-api', token)
+      await schema.$ready
+      expect(fetch).toHaveBeenLastCalledWith('http://localhost/pk-api', expect.objectContaining({
+        headers: new Headers({
+          'Accept-Language': 'en',
+          Authorization: `Bearer ${token}`
+        })
+      }))
     })
   })
 


### PR DESCRIPTION
# Problem
Previously `fetchSchema` used the raw node `fetch` function. This resulted in `fetchSchema` not respecting the [default headers](https://github.com/technowledgy/vue-postgrest/blob/main/src/request.js#L4) provided to vue-postgrest during its initialization.

# Solution
This PR changes the `fetchSchema` function to use the internal fetch wrapper called `request` which respects those header settings.

# Noteworthy Changes
- The request wrapper appends a trailing slash to the URL (e.g. all test URLs were updated from `/pk-api` to `/pk-api/`). This should work with all PostgREST servers since it serves the OpenAPI spec at both paths but its worth mentioning anyways.
- The `$isDirty` assertion changed in one of the tests. I'll leave an additional comment at the specific test. My take is that it was wrong before and got fixed with this change.
