### PR TITLE
Expose setDefaultRoot in the public library interface

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -136,6 +136,31 @@ The `vue-postgrest` module exports a plugin, a mixin and several helper function
   })
   ```
 
+### setDefaultRoot(apiRoot)
+
+- **Type:** `Function`
+
+- **Arguments:**
+  - `{string} apiRoot`
+
+- **Returns:** `undefined`
+
+- **Usage:**
+
+  Set the default API root used for all requests. Useful for setting the API root globally after the plugin has been installed, e.g. in response to a user action.
+
+  ::: tip
+  You can also set the API root at install time via the [plugin option](./#apiroot).
+  :::
+
+- **Example:**
+
+  ``` js
+  import { setDefaultRoot } from 'vue-postgrest'
+
+  setDefaultRoot('/api/v2/')
+  ```
+
 ### usePostgrest(apiRoot, token)
 
 - **Type:** `Function`

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import Plugin from '@/Plugin'
-import { resetSchemaCache, setDefaultToken } from '@/Schema'
+import { resetSchemaCache, setDefaultRoot, setDefaultToken } from '@/Schema'
 import { setDefaultHeaders } from '@/headers'
 import pg from '@/mixin'
 import { AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError } from '@/errors'
 import usePostgrest from '@/use'
 
-export { pg, AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError, resetSchemaCache, setDefaultHeaders, setDefaultToken, usePostgrest, Plugin as default }
+export { pg, AuthError, FetchError, PrimaryKeyError, SchemaNotFoundError, resetSchemaCache, setDefaultHeaders, setDefaultRoot, setDefaultToken, usePostgrest, Plugin as default }


### PR DESCRIPTION
This publicly exposes `setDefaultRoot` and thus lets users change the default api root of an already instanciated vue postgrest instance.